### PR TITLE
convert_ints_to_floats on old versions of NumPy

### DIFF
--- a/mmtf/converters/numpy_converters.py
+++ b/mmtf/converters/numpy_converters.py
@@ -27,7 +27,7 @@ def convert_ints_to_floats(in_ints, divider):
     :param in_ints: the integer array
     :param divider: the divider
     :return the array of floats produced"""
-    return (in_ints.astype(dtype=numpy.float64) / divider)
+    return (in_ints.astype(numpy.float64) / divider)
 
 def recursive_index_decode(int_array, max=32767, min=-32768):
     """Unpack an array of integers using recursive indexing.


### PR DESCRIPTION
Change to using a positional argument which works on old and current versions of NumPy.

The current code using a keyword argument can fail on older versions of NumPy:

```
$ python2.6 -c "import numpy as np; print(np.__version__); print(np.array([1,2,3]).astype(dtype=np.float64))"
1.6.2
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: astype() takes no keyword arguments
```

Suggested approach:

```
$ python2.6 -c "import numpy as np; print(np.__version__); print(np.array([1,2,3]).astype(np.float64))"
1.6.2
[ 1.  2.  3.]
```

For comparison, both forms work on more recent Python and NumPy installs:

```
$ python3.5 -c "import numpy as np; print(np.__version__); print(np.array([1,2,3]).astype(dtype=np.float64))"
1.11.0
[ 1.  2.  3.]
```

```
$ python3.5 -c "import numpy as np; print(np.__version__); print(np.array([1,2,3]).astype(np.float64))"
1.11.0
[ 1.  2.  3.]
```
