### PR TITLE
Changed classes to new style

### DIFF
--- a/mmtf/api/mmtf_reader.py
+++ b/mmtf/api/mmtf_reader.py
@@ -3,7 +3,7 @@ from mmtf.utils import decoder_utils
 import sys
 
 
-class MMTFDecoder():
+class MMTFDecoder(object):
     """Class to decode raw mmtf data into a parsed data model that can be fed into other data model"""
     model_counter = 0
     chain_counter = 0

--- a/mmtf/api/mmtf_writer.py
+++ b/mmtf/api/mmtf_writer.py
@@ -10,7 +10,7 @@ def make_entity_dict(chain_indices,sequence,description,entity_type):
     out_d["sequence"] = sequence
     return out_d
 
-class Group():
+class Group(object):
 
     def __eq__(self, other):
         """Function to define equality"""
@@ -65,7 +65,7 @@ def get_unique_groups(input_list):
     return out_list
 
 
-class TemplateEncoder():
+class TemplateEncoder(object):
     """Template class to be used by third parties to pass data into other data structures."""
 
     def init_structure(self, total_num_bonds, total_num_atoms,


### PR DESCRIPTION
For Py2/3 compatibility

Seems like a pedantic change, but it changes some behaviour eg

```python
class A():
    pass

class B(object):
    pass

a = A()
b = B()
```

`len(a)` raises an `AttributeError` but `len(b)` raises a `TypeError`

In Python 3 the `object` will be implicit, so this also makes things future proof/ready

http://stackoverflow.com/questions/4015417/python-class-inherits-object