### PR TITLE
use contextmanager to open/close files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,7 @@ All notable changes to this project will be documented in this file, following t
 ## v1.0.8 - 2017-08-17
 ### Fixed
 - Changing ascii to utf8 #29
+
+## v1.0.x - 20XX-XX-XX
+### Fixed
+- Don't leak open file handles #32

--- a/mmtf/api/default_api.py
+++ b/mmtf/api/default_api.py
@@ -87,7 +87,8 @@ def parse(file_path):
     :param file_path: the input file path. Data is not entropy compressed (e.g. gzip)
     :return an API to decoded data """
     newDecoder = MMTFDecoder()
-    newDecoder.decode_data(msgpack.unpackb(open(file_path, "rb").read()))
+    with open(file_path, "rb") as fh:
+        newDecoder.decode_data(msgpack.unpackb(fh.read()))
     return newDecoder
 
 

--- a/mmtf/api/mmtf_writer.py
+++ b/mmtf/api/mmtf_writer.py
@@ -256,8 +256,8 @@ class MMTFEncoder(TemplateEncoder):
 
 
     def write_file(self, file_path):
-        out_f = open(file_path, "wb")
-        out_f.write(self.get_msgpack())
+        with open(file_path, "wb") as out_f:
+            out_f.write(self.get_msgpack())
 
 
     def init_structure(self, total_num_bonds, total_num_atoms,

--- a/mmtf/tests/codec_tests.py
+++ b/mmtf/tests/codec_tests.py
@@ -190,7 +190,8 @@ class ConverterTests(unittest.TestCase):
         decoded.decode_data(msgpack.unpackb(packed))
 
     def test_gzip_open(self):
-        ungzip_data(open("mmtf/tests/testdatastore/4CUP.mmtf.gz","rb").read())
+        with open("mmtf/tests/testdatastore/4CUP.mmtf.gz","rb") as fh:
+            ungzip_data(fh.read())
 
     def test_fetch(self):
         if _internet_on(BASE_URL):


### PR DESCRIPTION
This helps cleaning up files access and ensures that they are closed
again. This will stop the leaks happening.