### PR TITLE
fix: default entity description to empty string

### DIFF
--- a/mmtf/utils/decoder_utils.py
+++ b/mmtf/utils/decoder_utils.py
@@ -155,7 +155,7 @@ def add_entity_info( data_api, struct_inflator):
     for entity in data_api.entity_list:
         struct_inflator.set_entity_info(entity["chainIndexList"],
                                         entity["sequence"],
-                                        entity["description"],
+                                        entity.get("description", ""),
                                         entity["type"])
 
 


### PR DESCRIPTION
BioJava doesn't always populate the field, would crash with key error.

closes #51