### PR TITLE
Updated requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ipython==5.4.1
+ipython
 numpy
 nose
-msgpack==0.5.6
+msgpack>=1.0.0


### PR DESCRIPTION
msgpack was pinned because of a bug in 0.6,
msgpack-python has had v1.0 for about 2 years

ipython pin seemed like it was for Python 3.4 reasons